### PR TITLE
Allow either the sender or the receiver to be the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,58 @@
-#filetran
+# filetran
 
-This is a *very simple* program to transfer a single file from one machine to another. I've used this while playing with [docker](http://docker.io) containers and transfering some config files to my nexus 7 running Arch. This was a quick and easy way to use node to solve a problem I had ;) 
+This is a *very simple* program to transfer a single file from one machine to another. I've used this while playing with [docker](http://docker.io) containers and transfering some config files to my nexus 7 running Arch. This was a quick and easy way to use node to solve a problem I had ;)
 
-##Install
+## Install
+
 ```sh
 npm install filetran -g
 ```
 
-##Usage
+## Usage
+
 Run the program in one of two modes:
 
-Mode| Description|Arguments
-----|------------|---------
-receive|Setup to recieve a file.|--port the port to listen on, file-name
-send|Send a file to another host|--host --port destination host and port, the file-name to send.
+| Mode   | Description |
+|--------|-------------|
+| Server | Setup to send or receive a file. |
+| Client | Connect to a server to send/recieve a file |
 
-###Example Receive
-You should start the receiver first, the sender needs to connect to this. 
+### `filetran <cmd> [opts] <file>`
 
+#### cmd
+
+- `send`: send a file to another filetran process.
+- `receive`: receive a file from another filetran process.
+
+#### opts
+- port, `-p`, `--port`: The port to connect to or to listen on.
+- host, `-h`, `--host`: The host to connect to.
+	- The host option can be used on either send or receive. (But not both at once.)
+	- If the host is not specified, it acts as a server. (Run this first).
+	- If a host is specified, it acts as a client. (Run this second).
+
+#### file
+
+- The filename to read from or write to. (The filenames do not need to match.)
+
+## Example
+
+You should start the server first, the client needs to connect to this. To start a server, just don't specify the host.
+
+##### Send:
 ```sh
 filetran receive -p 8790 test-file
 ```
 
-The receiver is now listening on port 8790 and will write what it receives to a file called *test-file*
+The server is now listening on port 8790, and will write what it receives to a file called *test-file*.
 
-###Example Send
+##### Receive:
 ```sh
 filetran send --host new-host --port 8790 test-file
 ```
 
-*note: the files names do not need to match on sender and receiver.*
+The client is now connecting to port 8790, and will send the contents of  *test-file* to the server.
 
+## License
+
+[MIT](http://opensource.org/licenses/MIT)

--- a/bin/echo-usage.js
+++ b/bin/echo-usage.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+
+module.exports = function echoUsage() {
+  var stream = fs.createReadStream(path.join(__dirname, 'usage.txt'));
+  stream.pipe(process.stdout);
+  stream.on('close', function () {
+    process.exit(1);
+  });
+};

--- a/bin/filetran
+++ b/bin/filetran
@@ -1,22 +1,25 @@
 #!/usr/bin/env node
 
-var fs = require('fs');
-var path = require('path');
-var send = require('../lib/send');
-var recv = require('../lib/recv');
+var action = {
+  send: require('../lib/send'),
+  receive: require('../lib/recv')
+};
+var server = require('../lib/server');
+var client = require('../lib/client');
+var echoUsage = require('./echo-usage');
 var parseArgs = require('minimist');
-var argOpts = { alias:{h:'host', p:'port'}};
+var argOpts = { alias:{ h:'host', p:'port' }};
 
 var argv = parseArgs(process.argv.slice(2), argOpts);
 var cmd = argv._[0];
 var file = argv._[1];
+var port = argv.port || 8080;
 
-if(cmd === 'send') {
-  send(file, argv.host, argv.port);
-} else if (cmd === 'receive') {
-  recv(argv.port, file);
+var sendOrRecieve = action[cmd];
+if (sendOrRecieve && file && argv.host) {
+  client(argv.host, port, sendOrRecieve(file));
+} else if (sendOrRecieve && file && !argv.host) {
+  server(port, sendOrRecieve(file));
 } else {
-  fs.createReadStream(path.join(__dirname, '/usage.txt')).
-    pipe(process.stdout);
+  echoUsage();
 }
-

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -1,5 +1,20 @@
 usage:
+  filetran <cmd> [opts] <file>
 
-  filetran send -h HOST -p PORT FILE
+  cmd:
+    send: send a file to another filetran process
+    receive: receive a file from another filetran process
 
-  filetran receive -p PORT FILE 
+  opts:
+    -p, --port: The port to connect to or to listen on.
+    -h, --host: The host to connect to.
+                The host option can be used on either send or receive, but not both at once.
+                If the host is not specified, it acts as a server (run this first).
+                If a host is specified, it acts as a client (run this second).
+
+  file:
+    The filename to read from or write to. (The filenames do not need to match.)
+
+examples:
+  filetran receive -p 3000 my-awesome-file.txt
+  filetran send -h localhost -p 3000 my-file.js

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var net = require('net');
+
+module.exports = function client(host, port, cb) {
+  var stream = new net.Socket();
+  stream.connect(port, host);
+  cb(stream);
+};

--- a/lib/recv.js
+++ b/lib/recv.js
@@ -1,24 +1,11 @@
 'use strict';
 
-var net = require('net');
 var fs = require('fs');
 var zlib = require('zlib');
 
-module.exports = function recv(port, file, cb) {
-  var server = net.createServer(function(c) {
+module.exports = function recv(file) {
+  return function onStream(stream) {
     var gunzip = zlib.createGunzip();
-    cb = cb  || function(){};
-
-    c.pipe(gunzip).pipe(fs.createWriteStream(file));
-
-    c.on('end', function() {
-      console.log('closiing');
-      server.close();
-    });
-
-  });
-
-  console.log('listen');
-  server.listen(port, cb);
+    stream.pipe(gunzip).pipe(fs.createWriteStream(file));
+  };
 };
-

--- a/lib/send.js
+++ b/lib/send.js
@@ -1,14 +1,11 @@
 'use strict';
 
-var net = require('net');
 var fs = require('fs');
 var zlib = require('zlib');
 
-module.exports = function send(file, host, port) {
-  var s = new net.Socket();
-  var gzip = zlib.createGzip();
-  s.connect(port, host);
-
-  fs.createReadStream(file).pipe(gzip).pipe(s);
+module.exports = function send(file) {
+  return function onStream(stream) {
+    var gzip = zlib.createGzip();
+    fs.createReadStream(file).pipe(gzip).pipe(stream);
+  };
 };
-

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var net = require('net');
+
+module.exports = function recv(port, cb) {
+  var server = net.createServer(function(stream) {
+    if (cb) {
+      cb(stream);
+      cb = null;
+    }
+
+    stream.on('end', function() {
+      server.close();
+    });
+  });
+
+  server.listen(port);
+};

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "filetran",
   "version": "0.0.4",
-  "description": "Simple file transfer tool I've found useful.",
+  "description": "Simple command-line file transfer tool",
   "bin": "./bin/filetran",
   "repository": {
     "type": "git",
     "url": "git://github.com/gangleri/filetran.git"
   },
   "scripts": {
-    "test": "tape ./tests"
+    "test": "tape ./test/*.js"
   },
   "keywords": [
     "file",
@@ -17,9 +17,11 @@
   "author": "Alan Bradley",
   "license": "MIT",
   "dependencies": {
-    "minimist": "^0.1.0"
+    "minimist": "^1.2.0"
   },
   "devDependencies": {
-    "tape": "^2.13.1"
+    "after": "^0.8.1",
+    "tape": "^4.2.2",
+    "tape-spawn": "^1.4.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+var test = require('tape');
+var after = require('after');
+var spawn = require('tape-spawn');
+var fs = require('fs');
+var path = require('path');
+
+var spawnOpts = { cwd: path.join(__dirname, '..') };
+var spawnOptsNoEnd = { cwd: path.join(__dirname, '..'), end: false };
+var usageText = fs.readFileSync(path.join(__dirname, '..', 'bin', 'usage.txt'), 'utf8');
+var readmePath = path.join(__dirname, '..', 'README.md');
+var readmeText = fs.readFileSync(readmePath, 'utf8');
+
+test('show usage when no args are supplied', function (t) {
+  var st = spawn(t, 'node bin/filetran', spawnOpts);
+  st.stdout.match(usageText);
+  st.stderr.empty();
+  st.fails();
+  st.end();
+});
+
+test('show usage when no file is supplied', function (t) {
+  var st = spawn(t, 'node bin/filetran send -p 1234', spawnOpts);
+  st.stdout.match(usageText);
+  st.stderr.empty();
+  st.fails();
+  st.end();
+});
+
+test('show usage when receive is misspelled', function (t) {
+  var st = spawn(t, 'node bin/filetran recieve derp', spawnOpts);
+  st.stdout.match(usageText);
+  st.stderr.empty();
+  st.fails();
+  st.end();
+});
+
+test('sender as server, receiver as client', function (t) {
+  var transferredReadmePath = path.join(__dirname, '_readme1.md');
+  var next = after(2, function () {
+    var transferredReadmeText = fs.readFileSync(transferredReadmePath, 'utf8');
+    t.equal(readmeText, transferredReadmeText);
+    fs.unlinkSync(transferredReadmePath);
+    t.end();
+  });
+
+  var st1 = spawn(t, 'node bin/filetran send README.md', spawnOptsNoEnd);
+  st1.stdout.empty();
+  st1.stderr.empty();
+  st1.succeeds();
+  st1.end(next);
+
+  var st2 = spawn(t, 'node bin/filetran receive -h localhost "' + transferredReadmePath + '"', spawnOptsNoEnd);
+  st2.stdout.empty();
+  st2.stderr.empty();
+  st2.succeeds();
+  st2.end(next);
+});
+
+test('receiver as server, sender as client', function (t) {
+  var transferredReadmePath = path.join(__dirname, '_readme2.md');
+  var next = after(2, function () {
+    var transferredReadmeText = fs.readFileSync(transferredReadmePath, 'utf8');
+    t.equal(readmeText, transferredReadmeText);
+    fs.unlinkSync(transferredReadmePath);
+    t.end();
+  });
+
+  var st1 = spawn(t, 'node bin/filetran receive "' + transferredReadmePath + '"', spawnOptsNoEnd);
+  st1.stdout.empty();
+  st1.stderr.empty();
+  st1.succeeds();
+  st1.end(next);
+
+  var st2 = spawn(t, 'node bin/filetran send -h localhost README.md', spawnOptsNoEnd);
+  st2.stdout.empty();
+  st2.stderr.empty();
+  st2.succeeds();
+  st2.end(next);
+});


### PR DESCRIPTION
Notable changes:
- Fix readme headers for npm
- Allow either the sender or the receiver to be the server
  - Split server and client pieces into separate files
  - Update docs to reflect changes (usage.txt, README.md)
- Update minimist
- Add tests
